### PR TITLE
refactor: make otp notifications configurable

### DIFF
--- a/app/Notifications/CustomOneTimePasswordNotification.php
+++ b/app/Notifications/CustomOneTimePasswordNotification.php
@@ -11,7 +11,7 @@ class CustomOneTimePasswordNotification extends OneTimePasswordNotification
 {
     public function via($notifiable): string|array
     {
-        return ['mail', 'vonage'];
+        return config('one-time-passwords.notification_channels', []);
     }
 
     // Email notification

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Log;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -19,6 +20,57 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        $this->validateOtpNotificationConfig();
+    }
+
+    /**
+     * Validate OTP notification configuration during application boot
+     */
+    private function validateOtpNotificationConfig(): void
+    {
+        // Only validate in non-testing environments to avoid issues during tests
+        if (app()->environment('testing')) {
+            return;
+        }
+
+        $channels = config('one-time-passwords.notification_channels', []);
+        $envValue = env('OTP_NOTIFICATION_CHANNELS');
+
+        // Warn about missing configuration
+        if (empty($channels)) {
+            $message = 'OTP notification channels not configured. Set OTP_NOTIFICATION_CHANNELS in your .env file.';
+
+            Log::warning($message, [
+                'suggestion' => 'Add OTP_NOTIFICATION_CHANNELS=mail,vonage to your .env file',
+                'current_env_value' => $envValue,
+            ]);
+
+            // In development, also output to console for immediate visibility
+            if (app()->environment('local')) {
+                echo "\n⚠️  WARNING: {$message}\n";
+                echo "   Add this to your .env file: OTP_NOTIFICATION_CHANNELS=mail,vonage\n\n";
+            }
+        }
+
+        // Validate supported channels
+        if (!empty($channels)) {
+            $supportedChannels = ['mail', 'vonage'];
+            $invalidChannels = array_diff($channels, $supportedChannels);
+
+            if (!empty($invalidChannels)) {
+                $message = 'Invalid OTP notification channels configured: ' . implode(', ', $invalidChannels);
+
+                Log::error($message, [
+                    'configured_channels' => $channels,
+                    'invalid_channels' => $invalidChannels,
+                    'supported_channels' => $supportedChannels,
+                ]);
+
+                if (app()->environment('local')) {
+                    echo "\n❌ ERROR: {$message}\n";
+                    echo "   Supported channels: " . implode(', ', $supportedChannels) . "\n\n";
+                }
+            }
+        }
     }
 }

--- a/config/one-time-passwords.php
+++ b/config/one-time-passwords.php
@@ -64,6 +64,16 @@ return [
     'notification' => App\Notifications\CustomOneTimePasswordNotification::class,
 
     /*
+     * The notification channels to use for sending one-time passwords.
+     * Available channels: 'mail', 'vonage' (SMS)
+     * You can specify multiple channels separated by commas in your .env file
+     * Example: OTP_NOTIFICATION_CHANNELS=mail,vonage
+     */
+    'notification_channels' => array_filter(
+        array_map('trim', explode(',', env('OTP_NOTIFICATION_CHANNELS', 'mail,vonage')))
+    ),
+
+    /*
      * These class are responsible for performing core tasks regarding one-time passwords.
      * You can customize them by creating a class that extends the default, and
      * by specifying your custom class name here.


### PR DESCRIPTION
Added an env variable for otp channels. Results in being able to use mail while developing and vonage (aka sms) in production.

Add this to your .env file to be ready for the change:
```bash
OTP_NOTIFICATION_CHANNELS="mail"
```
